### PR TITLE
fix #11

### DIFF
--- a/anonimongo.nimble
+++ b/anonimongo.nimble
@@ -10,7 +10,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.2.0", "nimSHA2 >= 0.1.1", "scram >= 0.1.9",
-         "sha1 >= 1.1", "dnsclient#head"
+         "sha1 >= 1.1", "dnsclient"
 
 task bson, "Unit test Bson":
   exec "nim c -r ./tests/test_bson_test.nim"


### PR DESCRIPTION
not super sure about this PR, but it at least allows client code to do:
```
nimble install https://github.com/timotheecour/dnsclient.nim@#pr_fix_3
nimble install anonimongo
```
otherwise, it would insist on installing dnsclient at head